### PR TITLE
Ensure IBM Plex Mono font loads reliably

### DIFF
--- a/invoice-generator.html
+++ b/invoice-generator.html
@@ -5,9 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>TECHNICAL INVOICE GENERATOR • Datasheet PDF</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap"
+    />
     <style>
       /* Site UI font (PDF uses embedded fonts below) */
-      @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap');
 
       :root {
         --ui-bg-light: #fff;


### PR DESCRIPTION
## Summary
- switch the IBM Plex Mono webfont to load via `<link>` tags instead of a CSS `@import`
- add preconnect hints for Google Fonts hosts to improve load reliability

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb93beb8e48333b25e23d5785e0c39