### PR TITLE
Fix PDF font loading by using CORS-friendly CDN

### DIFF
--- a/invoice-generator.html
+++ b/invoice-generator.html
@@ -1066,8 +1066,8 @@ Account Number: 483091305810</textarea
           input: 'fontHdr',
           status: 'fontHdrStatus',
           urls: [
-            'https://unpkg.com/@fontsource/rubik-mono-one/files/rubik-mono-one-latin-400-normal.ttf',
-            'https://unpkg.com/@fontsource/rubik-mono-one/files/rubik-mono-one-all-400-normal.ttf',
+            'https://fonts.gstatic.com/s/rubikmonoone/v20/UqyJK8kPP3hjw6ANTdfRk9YSN-8w.ttf',
+            'https://fonts.gstatic.com/s/rubikmonoone/v20/UqyJK8kPP3hjw6ANTdfRk9YSN-8w.ttf',
           ],
         },
         body: {
@@ -1076,8 +1076,8 @@ Account Number: 483091305810</textarea
           input: 'fontBody',
           status: 'fontBodyStatus',
           urls: [
-            'https://unpkg.com/@fontsource/dm-mono/files/dm-mono-latin-300-normal.ttf',
-            'https://unpkg.com/@fontsource/dm-mono/files/dm-mono-all-300-normal.ttf',
+            'https://fonts.gstatic.com/s/dmmono/v16/aFTR7PB1QTsUX8KYvrGyIYQ.ttf',
+            'https://fonts.gstatic.com/s/dmmono/v16/aFTR7PB1QTsUX8KYvrGyIYQ.ttf',
           ],
         },
       }


### PR DESCRIPTION
## Summary
- switch embedded PDF font URLs to fonts.gstatic.com to avoid missing CORS headers when fetching from unpkg

## Testing
- not run (static site, no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb966a87e883338aba408ebf5fe1e0