### PR TITLE
Adjust invoice styling and restore PDF export

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,7 @@
 
   function derivePalette(accent) {
     const { r, g, b } = hexToRgb(accent)
+    const accentRgb = `${r}, ${g}, ${b}`
     const brightness = (0.299 * r + 0.587 * g + 0.114 * b) / 255
     const inkStrong = greyFromLightness(clamp(brightness * 0.35 + 0.18, 0.12, 0.32))
     const ink = greyFromLightness(clamp(brightness * 0.45 + 0.28, 0.18, 0.45))
@@ -57,6 +58,7 @@
     const surfaceStrong = greyFromLightness(clamp(brightness * 0.6 + 0.7, 0.78, 0.96))
     return {
       accent,
+      accentRgb,
       inkStrong,
       ink,
       inkMuted,
@@ -266,12 +268,22 @@
   function applyPalette(element, palette) {
     if (!element) return
     element.style.setProperty('--accent', palette.accent)
+    element.style.setProperty('--accent-rgb', palette.accentRgb)
     element.style.setProperty('--ink-strong', palette.inkStrong)
     element.style.setProperty('--ink', palette.ink)
     element.style.setProperty('--ink-muted', palette.inkMuted)
     element.style.setProperty('--border', palette.border)
     element.style.setProperty('--surface', palette.surface)
     element.style.setProperty('--surface-strong', palette.surfaceStrong)
+  }
+
+  function updateUiAccent(color) {
+    document.documentElement.style.setProperty('--ui-accent', color)
+    const accentPicker = $('#accentColor')
+    if (accentPicker) {
+      accentPicker.style.borderColor = color
+      accentPicker.style.boxShadow = `0 0 0 1px ${color}`
+    }
   }
 
   function updatePreview() {
@@ -286,6 +298,7 @@
 
     invoiceElement.className = `invoice invoice--${panelStyle.value}`
     applyPalette(invoiceElement, palette)
+    updateUiAccent(palette.accent)
     invoiceElement.innerHTML = buildInvoiceMarkup(data)
   }
 
@@ -449,6 +462,12 @@
       clone.style.position = 'absolute'
       clone.style.left = '-9999px'
       clone.style.top = '0'
+      const computed = window.getComputedStyle(invoiceElement)
+      clone.style.width = computed.width
+      clone.style.margin = '0'
+      clone.style.maxWidth = 'none'
+      clone.style.background = computed.backgroundColor
+      clone.style.padding = computed.padding
       document.body.appendChild(clone)
 
       try {

--- a/invoice-generator.html
+++ b/invoice-generator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Technical Invoice Generator • Datasheet PDF</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@
   --ui-fg-light: #161616;
   --ui-bg-dark: #040404;
   --ui-fg-dark: #f3f3f3;
+  --ui-accent: #1a4dff;
 }
 
 html,
@@ -44,10 +45,9 @@ main.app {
 .card {
   background: color-mix(in srgb, currentColor 3%, transparent);
   border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-  border-radius: 18px;
   padding: clamp(20px, 3vw, 32px);
   backdrop-filter: blur(6px);
-  box-shadow: 0 24px 48px -36px rgba(0, 0, 0, 0.55);
+  box-shadow: 0 24px 48px -36px rgba(0, 0, 0, 0.35);
 }
 
 .masthead {
@@ -120,7 +120,6 @@ main.app {
 
 .field__control {
   border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
-  border-radius: 12px;
   padding: 12px;
   font-family: inherit;
   font-size: 14px;
@@ -129,7 +128,7 @@ main.app {
 }
 
 .field__control:focus {
-  outline: 2px solid currentColor;
+  outline: 2px solid var(--ui-accent);
   outline-offset: 2px;
 }
 
@@ -140,7 +139,6 @@ main.app {
 
 .field--radio {
   padding: 18px;
-  border-radius: 12px;
   border: 1px dashed color-mix(in srgb, currentColor 22%, transparent);
   gap: 12px;
 }
@@ -167,10 +165,32 @@ main.app {
   height: 18px;
 }
 
+input[type='radio'],
+input[type='checkbox'] {
+  accent-color: var(--ui-accent);
+}
+
+#accentColor {
+  width: 100%;
+  height: 42px;
+  padding: 0;
+  border: 1px solid var(--ui-accent);
+  background: transparent;
+  cursor: pointer;
+}
+
+#accentColor::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+#accentColor::-webkit-color-swatch,
+#accentColor::-moz-color-swatch {
+  border: none;
+}
+
 .logo-preview {
   grid-column: 1 / -1;
   border: 1px dashed color-mix(in srgb, currentColor 22%, transparent);
-  border-radius: 12px;
   padding: 12px;
   display: flex;
   align-items: center;
@@ -212,7 +232,6 @@ main.app {
 
 .preview__canvas {
   background: color-mix(in srgb, currentColor 8%, transparent);
-  border-radius: 16px;
   padding: clamp(18px, 3vw, 28px);
   border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
   overflow-x: auto;
@@ -224,12 +243,16 @@ main.app {
   text-transform: uppercase;
   letter-spacing: 0.3em;
   padding: 10px 20px;
-  border-radius: 999px;
   border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
   background: transparent;
   color: inherit;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:focus {
+  outline: 2px solid var(--ui-accent);
+  outline-offset: 2px;
 }
 
 .btn:hover {
@@ -238,12 +261,13 @@ main.app {
 }
 
 .btn--primary {
-  background: color-mix(in srgb, currentColor 12%, transparent);
+  background: var(--ui-accent);
+  border-color: var(--ui-accent);
+  color: #fff;
 }
 
 .table-wrap {
   overflow-x: auto;
-  border-radius: 12px;
   border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
 }
 
@@ -277,7 +301,7 @@ main.app {
 }
 
 .items td input:focus {
-  outline: 2px solid currentColor;
+  outline: 2px solid var(--ui-accent);
   outline-offset: -2px;
 }
 
@@ -293,29 +317,28 @@ main.app {
 .items .remove-row {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
-  border: none;
-  background: color-mix(in srgb, currentColor 20%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  background: transparent;
   color: inherit;
   cursor: pointer;
 }
 
 .invoice {
   --accent: #1a4dff;
+  --accent-rgb: 26, 77, 255;
   --ink-strong: #1f1f1f;
   --ink: #2a2a2a;
   --ink-muted: #5c5c5c;
   --surface: #f5f5f5;
   --surface-strong: #e8e8e8;
   --border: #c7c7c7;
-  --corner-radius: 12px;
 
   background: #ffffff;
   color: var(--ink);
   padding: clamp(32px, 4vw, 48px);
-  border-radius: 18px;
   border: 1px solid var(--border);
-  min-width: 560px;
+  width: min(100%, 720px);
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -325,7 +348,7 @@ main.app {
   display: flex;
   justify-content: space-between;
   gap: 18px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 2px solid rgba(var(--accent-rgb), 0.6);
   padding-bottom: 16px;
 }
 
@@ -346,6 +369,9 @@ main.app {
   font-size: 16px;
   font-weight: 700;
   color: var(--accent);
+  padding: 6px 12px;
+  border: 1px solid rgba(var(--accent-rgb), 0.4);
+  background: rgba(var(--accent-rgb), 0.12);
 }
 
 .invoice__meta {
@@ -367,11 +393,12 @@ main.app {
 }
 
 .invoice-panel {
-  border-radius: var(--corner-radius);
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  background: transparent;
+  border: 1px solid transparent;
 }
 
 .invoice-panel__title {
@@ -402,7 +429,7 @@ main.app {
   text-transform: uppercase;
   letter-spacing: 0.24em;
   color: var(--accent);
-  background: var(--surface);
+  background: rgba(var(--accent-rgb), 0.1);
 }
 
 .invoice-table td:nth-child(2) {
@@ -421,12 +448,13 @@ main.app {
 }
 
 .invoice-summary__totals {
-  border-radius: var(--corner-radius);
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
   gap: 6px;
   font-size: 13px;
+  background: transparent;
+  border: 1px solid transparent;
 }
 
 .invoice-summary__line,
@@ -439,7 +467,7 @@ main.app {
   font-weight: 700;
   font-size: 14px;
   color: var(--ink-strong);
-  border-top: 1px solid var(--border);
+  border-top: 1px solid rgba(var(--accent-rgb), 0.35);
   padding-top: 8px;
 }
 
@@ -451,18 +479,18 @@ main.app {
 .invoice--outline .invoice-panel,
 .invoice--outline .invoice-summary__totals {
   border: 1px solid var(--border);
-  background: transparent;
+  background: #ffffff;
+  box-shadow: inset 0 -3px 0 rgba(var(--accent-rgb), 0.35);
 }
 
 .invoice--solid .invoice-panel,
 .invoice--solid .invoice-summary__totals {
   border: none;
-  background: var(--surface);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--surface) 20%, var(--accent));
+  background: rgba(var(--accent-rgb), 0.16);
 }
 
 .invoice--solid .invoice-table th {
-  background: var(--surface-strong);
+  background: rgba(var(--accent-rgb), 0.18);
 }
 
 @media (max-width: 960px) {
@@ -487,10 +515,15 @@ main.app {
   .preview__actions {
     width: 100%;
     justify-content: flex-start;
+    flex-direction: column;
+  }
+
+  .preview__actions .btn {
+    width: 100%;
   }
 
   .invoice {
-    min-width: 100%;
+    width: 100%;
     padding: 24px;
   }
 


### PR DESCRIPTION
## Summary
- add the html2canvas dependency and clone the styled invoice before passing it to jsPDF so PDF export works reliably
- remove rounded corners, restyle the invoice panels for outline and solid modes, and propagate the accent color through the UI
- tighten the layout for small screens so preview actions stack and the invoice scales fluidly on mobile

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbe1f8e39883339a594228caef9975