### PR TITLE
Keep invoice preview theme constant

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -547,8 +547,5 @@ input[type='checkbox'] {
     background: color-mix(in srgb, currentColor 8%, transparent);
   }
 
-  html[data-theme='system'] body .invoice,
-  html[data-theme='dark'] body .invoice {
-    background: #101010;
-  }
+  /* Keep the invoice preview styling consistent regardless of UI theme. */
 }


### PR DESCRIPTION
## Summary
- stop applying the selected UI theme to the invoice preview canvas so it always renders in its default style

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbe55094e08333af367723ee2342c5