### PR TITLE
Fix PDF export rendering and isolate preview theme

### DIFF
--- a/app.js
+++ b/app.js
@@ -462,8 +462,10 @@
       const computed = window.getComputedStyle(invoiceElement)
       const cloneWrapper = document.createElement('div')
       cloneWrapper.style.position = 'fixed'
-      cloneWrapper.style.left = '-9999px'
+      cloneWrapper.style.left = '0'
       cloneWrapper.style.top = '0'
+      cloneWrapper.style.visibility = 'hidden'
+      cloneWrapper.style.pointerEvents = 'none'
       cloneWrapper.style.background = computed.backgroundColor || '#ffffff'
       cloneWrapper.style.padding = '0'
       cloneWrapper.style.margin = '0'

--- a/styles.css
+++ b/styles.css
@@ -230,11 +230,22 @@ input[type='checkbox'] {
   flex-wrap: wrap;
 }
 
+.preview.card {
+  background: #ffffff;
+  color: var(--ui-fg-light);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
 .preview__canvas {
-  background: color-mix(in srgb, currentColor 8%, transparent);
+  background: #f4f4f4;
   padding: clamp(18px, 3vw, 28px);
-  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  border: 1px solid rgba(0, 0, 0, 0.12);
   overflow-x: auto;
+}
+
+.preview .btn {
+  color: var(--ui-fg-light);
+  border-color: rgba(0, 0, 0, 0.3);
 }
 
 .btn {
@@ -542,10 +553,20 @@ input[type='checkbox'] {
 }
 
 @media (prefers-color-scheme: dark) {
-  html[data-theme='system'] .card,
-  html[data-theme='dark'] .card {
+  html[data-theme='system'] .card:not(.preview),
+  html[data-theme='dark'] .card:not(.preview) {
     background: color-mix(in srgb, currentColor 8%, transparent);
   }
 
-  /* Keep the invoice preview styling consistent regardless of UI theme. */
+  html[data-theme='system'] .preview.card,
+  html[data-theme='dark'] .preview.card {
+    background: #ffffff;
+    color: var(--ui-fg-light);
+  }
+
+  html[data-theme='system'] .preview__canvas,
+  html[data-theme='dark'] .preview__canvas {
+    background: #f4f4f4;
+    border-color: rgba(0, 0, 0, 0.12);
+  }
 }


### PR DESCRIPTION
## Summary
- ensure the PDF capture clone stays visible to the renderer to avoid blank exports
- keep the preview card and canvas styling locked to the light scheme so theme toggles only affect the surrounding UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbe6f2daa88333b752b7954914f516