### PR TITLE
Rebuild invoice workspace with schematic-style preview

### DIFF
--- a/invoice-generator.html
+++ b/invoice-generator.html
@@ -1,202 +1,199 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="system">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Technical Invoice Generator • Datasheet PDF</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+    <title>Invoice Workbench • Histolysis Edition</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&family=Share+Tech+Mono&display=swap"
       rel="stylesheet"
     />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
     <link rel="stylesheet" href="styles.css" />
     <script src="app.js" defer></script>
   </head>
   <body>
-    <main class="app">
-      <header class="masthead card">
-        <div class="masthead__body">
-          <h1 class="masthead__title">Technical Invoice Generator</h1>
-          <p class="masthead__meta">Single page datasheet • Export ready PDF</p>
+    <main class="workspace" id="workspace">
+      <header class="workspace__masthead">
+        <div>
+          <p class="workspace__eyebrow">Circuit Lab Toolkit</p>
+          <h1 class="workspace__title">Invoice Workbench</h1>
+          <p class="workspace__subtitle">
+            Guided form + schematic preview so anyone can confirm the data and export the PDF in seconds.
+          </p>
         </div>
-        <div class="masthead__theme">
-          <label class="field">
-            <span class="field__label">Website theme</span>
-            <select id="uiTheme" class="field__control">
-              <option value="system">System</option>
+        <div class="workspace__toggles">
+          <label class="toggle">
+            <span class="toggle__label">Theme</span>
+            <select id="themeSelect" class="toggle__control">
               <option value="light">Light</option>
               <option value="dark">Dark</option>
             </select>
           </label>
+          <label class="toggle">
+            <span class="toggle__label">Accent</span>
+            <input type="color" id="accentPicker" class="toggle__control" value="#cc3651" />
+          </label>
         </div>
       </header>
 
-      <section class="card preview" id="previewSection">
-        <header class="preview__header">
-          <div>
-            <h2 class="preview__title">Template preview</h2>
-            <p class="preview__hint">The live sheet reflects every change instantly.</p>
-          </div>
-          <div class="preview__actions">
-            <button type="button" class="btn" id="refreshPreview">Refresh</button>
-            <button type="button" class="btn btn--primary" id="downloadPdf">
-              Download PDF
-            </button>
-          </div>
-        </header>
-        <div class="preview__canvas">
-          <div id="invoiceContent" class="invoice invoice--outline"></div>
-        </div>
-      </section>
-
-      <section class="card controls">
-        <h2 class="section-title">Template settings</h2>
-        <div class="grid grid--two">
-          <label class="field">
-            <span class="field__label">Paper size</span>
-            <select id="paperSize" class="field__control">
-              <option value="letter">Letter (8.5 × 11 in)</option>
-              <option value="a4">A4 (210 × 297 mm)</option>
-            </select>
-          </label>
-          <label class="field">
-            <span class="field__label">Orientation</span>
-            <select id="orientation" class="field__control">
-              <option value="portrait">Portrait</option>
-              <option value="landscape">Landscape</option>
-            </select>
-          </label>
-          <label class="field">
-            <span class="field__label">Accent color</span>
-            <input type="color" id="accentColor" class="field__control" value="#1a4dff" />
-          </label>
-          <fieldset class="field field--radio">
-            <legend class="field__label">Panel style</legend>
-            <div class="radio-list">
-              <label class="radio">
-                <input type="radio" name="panelStyle" value="outline" checked />
-                <span>Outline grid</span>
+      <section class="workspace__body">
+        <form id="invoiceForm" class="form">
+          <section class="form__card">
+            <h2 class="form__title">Layout preferences</h2>
+            <div class="form__grid form__grid--two">
+              <label class="field">
+                <span class="field__label">Orientation</span>
+                <select name="orientation" id="orientation" class="field__control">
+                  <option value="portrait" selected>Portrait (Letter)</option>
+                  <option value="landscape">Landscape (Letter)</option>
+                </select>
               </label>
-              <label class="radio">
-                <input type="radio" name="panelStyle" value="solid" />
-                <span>Solid fills</span>
+              <label class="field">
+                <span class="field__label">Panel density</span>
+                <select name="panelDensity" id="panelDensity" class="field__control">
+                  <option value="standard" selected>Standard grid</option>
+                  <option value="dense">Dense traces</option>
+                </select>
+              </label>
+              <label class="field field--span">
+                <span class="field__label">Optional logo</span>
+                <input type="file" id="logoInput" class="field__control" accept="image/*" />
+                <small class="field__hint">Upload PNG or SVG under 1MB.</small>
               </label>
             </div>
-          </fieldset>
-          <label class="field">
-            <span class="field__label">Logo</span>
-            <input type="file" id="logoUpload" class="field__control" accept="image/*" />
-            <small class="field__hint">PNG or SVG works best. Max 800px wide.</small>
-          </label>
-          <div class="logo-preview" id="logoPreview" hidden>
-            <img alt="Logo preview" id="logoPreviewImage" />
+            <figure class="logo-preview" id="logoPreview" hidden>
+              <img alt="Logo preview" id="logoPreviewImage" />
+            </figure>
+          </section>
+
+          <section class="form__card">
+            <h2 class="form__title">Sender</h2>
+            <div class="form__grid form__grid--two">
+              <label class="field">
+                <span class="field__label">Name</span>
+                <input type="text" id="fromName" class="field__control" value="David Yang" />
+              </label>
+              <label class="field">
+                <span class="field__label">Website</span>
+                <input type="text" id="fromWebsite" class="field__control" value="www.davidyang.work" />
+              </label>
+              <label class="field">
+                <span class="field__label">Phone</span>
+                <input type="text" id="fromPhone" class="field__control" value="480-787-9710" />
+              </label>
+              <label class="field field--span">
+                <span class="field__label">Address</span>
+                <input type="text" id="fromAddress" class="field__control" value="10 Montieth St, APT 241, Brooklyn, NY 11206" />
+              </label>
+            </div>
+          </section>
+
+          <section class="form__card">
+            <h2 class="form__title">Client</h2>
+            <div class="form__grid form__grid--two">
+              <label class="field">
+                <span class="field__label">Client name</span>
+                <input type="text" id="clientName" class="field__control" value="MORAKANA" />
+              </label>
+              <label class="field">
+                <span class="field__label">Project</span>
+                <input type="text" id="projectName" class="field__control" value="MORAKANA Histolysis" />
+              </label>
+              <label class="field field--span">
+                <span class="field__label">Billing contact</span>
+                <textarea id="clientContacts" rows="2" class="field__control">MORAKANA — Sebastián & Tiri
+493 Greene Ave, Brooklyn, NY 11216
+seb@morakana.com (312) 399-1519 • tiri@morakana.com (917) 456-2956</textarea>
+              </label>
+            </div>
+          </section>
+
+          <section class="form__card">
+            <h2 class="form__title">Key dates & terms</h2>
+            <div class="form__grid form__grid--three">
+              <label class="field">
+                <span class="field__label">Invoice number</span>
+                <input type="text" id="invoiceNumber" class="field__control" value="IN-19" />
+              </label>
+              <label class="field">
+                <span class="field__label">Invoice date</span>
+                <input type="date" id="invoiceDate" class="field__control" value="2025-07-11" />
+              </label>
+              <label class="field">
+                <span class="field__label">Due date</span>
+                <input type="date" id="dueDate" class="field__control" value="2025-08-11" />
+              </label>
+              <label class="field">
+                <span class="field__label">Issued</span>
+                <input type="date" id="issuedDate" class="field__control" value="2025-06-08" />
+              </label>
+              <label class="field">
+                <span class="field__label">Completed</span>
+                <input type="date" id="completedDate" class="field__control" value="2025-07-12" />
+              </label>
+              <label class="field">
+                <span class="field__label">Status</span>
+                <input type="text" id="invoiceStatus" class="field__control" value="Requested" />
+              </label>
+              <label class="field">
+                <span class="field__label">Currency</span>
+                <select id="currency" class="field__control">
+                  <option value="USD" selected>USD — United States Dollar</option>
+                  <option value="EUR">EUR — Euro</option>
+                  <option value="GBP">GBP — British Pound</option>
+                  <option value="JPY">JPY — Japanese Yen</option>
+                </select>
+              </label>
+            </div>
+          </section>
+
+          <section class="form__card">
+            <h2 class="form__title">Payment instructions</h2>
+            <label class="field field--span">
+              <span class="field__label">Details</span>
+              <textarea id="paymentDetails" rows="4" class="field__control">Transfer via Zelle or Venmo — davidyangfinance@gmail.com · 480-787-9710
+ACH Transfer — Routing 021000322 · Account 48309130581</textarea>
+            </label>
+            <label class="field field--span">
+              <span class="field__label">Invoice notes</span>
+              <textarea id="invoiceNotes" rows="3" class="field__control">Included the refund from JLCPCB about the Histolysis order.</textarea>
+            </label>
+          </section>
+
+          <section class="form__card">
+            <header class="form__heading">
+              <h2 class="form__title">Billable work</h2>
+              <button type="button" id="addLineItem" class="btn btn--ghost">Add row</button>
+            </header>
+            <div class="line-items">
+              <div class="line-items__header">
+                <span>Description</span>
+                <span>Hours / Qty</span>
+                <span>Rate</span>
+                <span>Amount</span>
+                <span></span>
+              </div>
+              <div class="line-items__body" id="lineItemsBody"></div>
+            </div>
+            <p class="form__note">
+              Empty rows disappear from the preview automatically so only recorded work reaches the PDF.
+            </p>
+          </section>
+        </form>
+
+        <aside class="preview">
+          <div class="preview__toolbar">
+            <button type="button" id="resetForm" class="btn btn--ghost">Reset to sample</button>
+            <button type="button" id="downloadPdf" class="btn btn--primary">Download PDF</button>
           </div>
-        </div>
-      </section>
-
-      <section class="card controls">
-        <h2 class="section-title">Sender &amp; recipient</h2>
-        <div class="grid grid--two">
-          <label class="field">
-            <span class="field__label">Sender name</span>
-            <input type="text" id="fromName" class="field__control" value="Morakana Studio" />
-          </label>
-          <label class="field">
-            <span class="field__label">Sender website</span>
-            <input type="text" id="fromWebsite" class="field__control" value="morakana.com" />
-          </label>
-          <label class="field">
-            <span class="field__label">Sender phone</span>
-            <input type="text" id="fromPhone" class="field__control" value="(480) 787-9710" />
-          </label>
-          <label class="field field--span">
-            <span class="field__label">Sender address</span>
-            <input
-              type="text"
-              id="fromAddress"
-              class="field__control"
-              value="493 Greene Ave, Brooklyn, NY 11216"
-            />
-          </label>
-          <label class="field">
-            <span class="field__label">Recipient company</span>
-            <input type="text" id="toCompany" class="field__control" value="Sebastian + Tiri" />
-          </label>
-          <label class="field">
-            <span class="field__label">Attention</span>
-            <input type="text" id="toAttention" class="field__control" value="Sebastián &amp; Tiri" />
-          </label>
-          <label class="field field--span">
-            <span class="field__label">Recipient address</span>
-            <input
-              type="text"
-              id="toAddress"
-              class="field__control"
-              value="493 Greene Ave, Brooklyn, NY 11216"
-            />
-          </label>
-          <label class="field field--span">
-            <span class="field__label">Recipient contact lines</span>
-            <textarea id="toContact" class="field__control" rows="3">seb@morakana.com (312) 399-1519
-tiri@morakana.com (917) 456-2956</textarea>
-          </label>
-        </div>
-      </section>
-
-      <section class="card controls">
-        <h2 class="section-title">Invoice details</h2>
-        <div class="grid grid--three">
-          <label class="field">
-            <span class="field__label">Invoice number</span>
-            <input type="text" id="invoiceNumber" class="field__control" value="IN-19" />
-          </label>
-          <label class="field">
-            <span class="field__label">Issue date</span>
-            <input type="date" id="invoiceDate" class="field__control" value="2025-07-11" />
-          </label>
-          <label class="field">
-            <span class="field__label">Due date</span>
-            <input type="date" id="dueDate" class="field__control" value="2025-08-11" />
-          </label>
-          <label class="field">
-            <span class="field__label">Currency</span>
-            <input type="text" id="currency" class="field__control" value="USD" />
-          </label>
-          <label class="field field--span">
-            <span class="field__label">Payment instructions</span>
-            <textarea id="paymentInstructions" class="field__control" rows="4">Transfer via Zelle or Venmo —
-davidyangfinance@gmail.com
-480-787-9710
-
-ACH Transfer Info —
-Routing Number: 021000322
-Account Number: 483091305810</textarea>
-          </label>
-        </div>
-      </section>
-
-      <section class="card controls">
-        <header class="section-head">
-          <h2 class="section-title">Line items</h2>
-          <button type="button" class="btn" id="addItem">+ Add line item</button>
-        </header>
-        <div class="table-wrap">
-          <table class="items" id="itemsTable">
-            <thead>
-              <tr>
-                <th>Description</th>
-                <th>Qty/Hrs</th>
-                <th>Rate</th>
-                <th>Amount</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody id="itemsBody"></tbody>
-          </table>
-        </div>
+          <div class="preview__stage">
+            <article id="invoicePreview" class="invoice sheet sheet--portrait"></article>
+          </div>
+        </aside>
       </section>
     </main>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,27 @@
 :root {
-  color-scheme: light dark;
-  --ui-bg-light: #f7f7f7;
-  --ui-fg-light: #161616;
-  --ui-bg-dark: #040404;
-  --ui-fg-dark: #f3f3f3;
-  --ui-accent: #1a4dff;
+  --bg: #f1f2f4;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-alt: rgba(240, 241, 245, 0.95);
+  --ink: #0d1522;
+  --ink-muted: #4b5566;
+  --grid-line: rgba(13, 21, 34, 0.08);
+  --trace: rgba(204, 54, 81, 0.25);
+  --accent: #cc3651;
+  --accent-strong: #ff4f73;
+  --outline: rgba(13, 21, 34, 0.12);
+  --card-shadow: 0 24px 80px -60px rgba(5, 8, 20, 0.7);
 }
 
-html,
-body {
-  height: 100%;
+[data-theme="dark"] {
+  --bg: #060810;
+  --surface: rgba(10, 14, 28, 0.82);
+  --surface-alt: rgba(16, 20, 33, 0.86);
+  --ink: #f7f9ff;
+  --ink-muted: #c5c9db;
+  --grid-line: rgba(197, 201, 219, 0.08);
+  --trace: rgba(255, 79, 115, 0.2);
+  --outline: rgba(197, 201, 219, 0.16);
+  --card-shadow: 0 24px 80px -48px rgba(0, 0, 0, 0.9);
 }
 
 * {
@@ -18,93 +30,177 @@ body {
 
 body {
   margin: 0;
-  font-family: 'IBM Plex Mono', monospace;
-  background: var(--ui-bg-light);
-  color: var(--ui-fg-light);
-  font-size: clamp(13px, 1.3vw, 15px);
-  line-height: 1.55;
+  font-family: "Space Grotesk", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  min-height: 100vh;
 }
 
-html[data-theme='dark'] body,
-@media (prefers-color-scheme: dark) {
-  html[data-theme='system'] body {
-    background: var(--ui-bg-dark);
-    color: var(--ui-fg-dark);
-  }
+img {
+  max-width: 100%;
+  display: block;
 }
 
-main.app {
-  max-width: 1100px;
+textarea,
+input,
+select,
+button {
+  font: inherit;
+  color: inherit;
+}
+
+.workspace {
+  max-width: 1400px;
   margin: 0 auto;
-  padding: clamp(20px, 4vw, 48px) clamp(16px, 5vw, 56px);
+  padding: 32px clamp(16px, 4vw, 48px) 80px;
   display: flex;
   flex-direction: column;
-  gap: clamp(18px, 3vw, 32px);
+  gap: 32px;
 }
 
-.card {
-  background: color-mix(in srgb, currentColor 3%, transparent);
-  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-  padding: clamp(20px, 3vw, 32px);
-  backdrop-filter: blur(6px);
-  box-shadow: 0 24px 48px -36px rgba(0, 0, 0, 0.35);
-}
-
-.masthead {
+.workspace__masthead {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
   justify-content: space-between;
+  gap: 32px;
+  align-items: flex-end;
+  padding: 24px clamp(24px, 5vw, 48px);
+  border: 2px solid var(--outline);
+  background: var(--surface);
+  backdrop-filter: blur(24px);
+  box-shadow: var(--card-shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.workspace__masthead::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 32px 32px;
+  opacity: 0.6;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.workspace__eyebrow {
+  font-family: "Share Tech Mono", monospace;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 13px;
+  margin: 0 0 8px;
+  color: var(--accent-strong);
+}
+
+.workspace__title {
+  margin: 0;
+  font-size: clamp(32px, 6vw, 54px);
+  line-height: 1.05;
+}
+
+.workspace__subtitle {
+  margin: 12px 0 0;
+  max-width: 480px;
+  color: var(--ink-muted);
+}
+
+.workspace__toggles {
+  display: flex;
+  gap: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.toggle {
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.toggle__label {
+  font-family: "Share Tech Mono", monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.toggle__control {
+  border: 1px solid var(--outline);
+  background: var(--surface-alt);
+  color: var(--ink);
+  padding: 6px 12px;
+  border-radius: 6px;
+}
+
+.workspace__body {
+  display: grid;
+  grid-template-columns: minmax(320px, 520px) minmax(420px, 1fr);
+  gap: 32px;
+  align-items: start;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form__card {
+  background: var(--surface);
+  border: 2px solid var(--outline);
+  padding: 24px clamp(16px, 3vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.form__card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 24px 24px;
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.form__title {
+  margin: 0;
+  position: relative;
+  z-index: 1;
+  font-size: 20px;
+}
+
+.form__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.form__grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
   gap: 18px;
 }
 
-.masthead__title {
-  text-transform: uppercase;
-  letter-spacing: 0.38em;
-  font-size: clamp(22px, 4.4vw, 32px);
-  margin: 0 0 8px;
-}
-
-.masthead__meta {
-  margin: 0;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
-  font-size: clamp(11px, 1.4vw, 14px);
-  opacity: 0.75;
-}
-
-.section-title {
-  margin: 0 0 18px;
-  text-transform: uppercase;
-  letter-spacing: 0.32em;
-  font-size: clamp(12px, 1.4vw, 14px);
-}
-
-.section-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 18px;
-}
-
-.controls .grid {
-  display: grid;
-  gap: 16px;
-}
-
-.grid--two {
+.form__grid--two {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.grid--three {
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+.form__grid--three {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .field--span {
@@ -112,466 +208,435 @@ main.app {
 }
 
 .field__label {
-  font-weight: 700;
-  letter-spacing: 0.28em;
-  font-size: 11px;
+  font-family: "Share Tech Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--ink-muted);
 }
 
 .field__control {
-  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
-  padding: 12px;
-  font-family: inherit;
-  font-size: 14px;
-  background: color-mix(in srgb, currentColor 4%, transparent);
+  border: 1px solid var(--outline);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: var(--surface-alt);
   color: inherit;
+  width: 100%;
+  resize: vertical;
 }
 
 .field__control:focus {
-  outline: 2px solid var(--ui-accent);
-  outline-offset: 2px;
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .field__hint {
   font-size: 12px;
-  opacity: 0.7;
-}
-
-.field--radio {
-  padding: 18px;
-  border: 1px dashed color-mix(in srgb, currentColor 22%, transparent);
-  gap: 12px;
-}
-
-.field--radio .field__label {
-  margin-bottom: 4px;
-}
-
-.radio-list {
-  display: flex;
-  gap: 18px;
-  flex-wrap: wrap;
-}
-
-.radio {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-}
-
-.radio input {
-  width: 18px;
-  height: 18px;
-}
-
-input[type='radio'],
-input[type='checkbox'] {
-  accent-color: var(--ui-accent);
-}
-
-#accentColor {
-  width: 100%;
-  height: 42px;
-  padding: 0;
-  border: 1px solid var(--ui-accent);
-  background: transparent;
-  cursor: pointer;
-}
-
-#accentColor::-webkit-color-swatch-wrapper {
-  padding: 0;
-}
-
-#accentColor::-webkit-color-swatch,
-#accentColor::-moz-color-swatch {
-  border: none;
+  color: var(--ink-muted);
 }
 
 .logo-preview {
-  grid-column: 1 / -1;
-  border: 1px dashed color-mix(in srgb, currentColor 22%, transparent);
+  position: relative;
+  z-index: 1;
+  border: 1px dashed var(--outline);
   padding: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: color-mix(in srgb, currentColor 3%, transparent);
-}
-
-.logo-preview img {
-  max-width: 220px;
-  max-height: 72px;
-}
-
-.preview__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: center;
-  margin-bottom: 18px;
-}
-
-.preview__title {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.32em;
-  font-size: clamp(14px, 1.6vw, 16px);
-}
-
-.preview__hint {
-  margin: 4px 0 0;
-  font-size: 13px;
-  opacity: 0.7;
-}
-
-.preview__actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.preview.card {
-  background: #ffffff;
-  color: var(--ui-fg-light);
-  border: 1px solid rgba(0, 0, 0, 0.12);
-}
-
-.preview__canvas {
-  background: #f4f4f4;
-  padding: clamp(18px, 3vw, 28px);
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  overflow: auto;
-  display: flex;
-  justify-content: center;
-  align-items: flex-end;
-}
-
-.preview .btn {
-  color: var(--ui-fg-light);
-  border-color: rgba(0, 0, 0, 0.3);
+  max-width: 240px;
+  background: var(--surface-alt);
 }
 
 .btn {
-  font-family: inherit;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.3em;
-  padding: 10px 20px;
-  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  position: relative;
+  z-index: 1;
+  border: 1px solid var(--accent);
   background: transparent;
-  color: inherit;
+  color: var(--accent);
+  padding: 10px 18px;
+  border-radius: 999px;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.btn:focus {
-  outline: 2px solid var(--ui-accent);
-  outline-offset: 2px;
+  font-weight: 600;
+  transition: background 0.2s, color 0.2s;
 }
 
 .btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px -18px rgba(0, 0, 0, 0.6);
-}
-
-.btn--primary {
-  background: var(--ui-accent);
-  border-color: var(--ui-accent);
+  background: var(--accent);
   color: #fff;
 }
 
-.table-wrap {
-  overflow-x: auto;
-  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+.btn--primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 12px 30px -20px var(--accent);
 }
 
-.items {
-  width: 100%;
-  border-collapse: collapse;
-  min-width: 640px;
+.btn--primary:hover {
+  filter: brightness(1.05);
 }
 
-.items th,
-.items td {
-  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-  padding: 8px;
+.btn--ghost {
+  border-color: var(--outline);
+  color: var(--ink);
+}
+
+.btn--ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.form__note {
+  font-size: 13px;
+  color: var(--ink-muted);
+  margin: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.line-items {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 8px;
+}
+
+.line-items__header,
+.line-items__row {
+  display: grid;
+  grid-template-columns: 2fr 0.9fr 0.9fr 1fr auto;
+  gap: 12px;
+  align-items: center;
+  font-family: "Share Tech Mono", monospace;
   font-size: 13px;
 }
 
-.items th {
+.line-items__header {
+  color: var(--ink-muted);
   text-transform: uppercase;
-  letter-spacing: 0.24em;
-  text-align: left;
-  background: color-mix(in srgb, currentColor 10%, transparent);
+  letter-spacing: 0.08em;
 }
 
-.items td input {
+.line-items__row textarea,
+.line-items__row input {
   width: 100%;
-  background: transparent;
-  border: none;
-  color: inherit;
-  font-family: inherit;
-  font-size: 13px;
 }
 
-.items td input:focus {
-  outline: 2px solid var(--ui-accent);
-  outline-offset: -2px;
+.line-items__row textarea {
+  min-height: 56px;
+  resize: vertical;
 }
 
-.items td:nth-child(2) input,
-.items td:nth-child(3) input {
-  text-align: center;
+.line-items__row input[type="number"] {
+  padding-right: 4px;
 }
 
-.items td:nth-child(4) input {
+.line-items__amount {
+  display: block;
+  padding: 10px 12px;
+  border: 1px solid var(--outline);
+  border-radius: 6px;
+  background: var(--surface-alt);
   text-align: right;
+  font-variant-numeric: tabular-nums;
+  min-width: 96px;
 }
 
-.items .remove-row {
-  width: 32px;
-  height: 32px;
-  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+.line-items__remove {
+  border: none;
   background: transparent;
-  color: inherit;
+  color: var(--ink-muted);
   cursor: pointer;
+  font-size: 18px;
+}
+
+.preview {
+  position: sticky;
+  top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.preview__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.preview__stage {
+  border: 2px solid var(--outline);
+  background: var(--surface);
+  padding: 24px;
+  box-shadow: var(--card-shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.preview__stage::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 32px 32px;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.sheet {
+  position: relative;
+  background: #fff;
+  color: #13203b;
+  width: clamp(320px, 38vw, 540px);
+  margin: 0 auto;
+  padding: 36px 40px 48px;
+  border: 4px solid var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+  font-family: "Share Tech Mono", monospace;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.sheet::after {
+  content: "";
+  position: absolute;
+  inset: 16px;
+  border: 1px solid var(--outline);
+  background-image: linear-gradient(var(--trace) 1px, transparent 1px),
+    linear-gradient(90deg, var(--trace) 1px, transparent 1px);
+  background-size: 28px 28px;
+  opacity: 0.35;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+  z-index: -1;
+}
+
+.sheet--dense::after {
+  background-size: 14px 14px;
+  opacity: 0.45;
+}
+
+[data-theme="dark"] .sheet {
+  background: #0b1020;
+  color: #f0f4ff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.sheet--landscape {
+  width: clamp(420px, 52vw, 720px);
+  aspect-ratio: 11 / 8.5;
+}
+
+.sheet--portrait {
+  aspect-ratio: 8.5 / 11;
 }
 
 .invoice {
-  --accent: #1a4dff;
-  --accent-rgb: 26, 77, 255;
-  --ink-strong: #1f1f1f;
-  --ink: #2a2a2a;
-  --ink-muted: #5c5c5c;
-  --surface: #f5f5f5;
-  --surface-strong: #e8e8e8;
-  --border: #c7c7c7;
-
-  background: #ffffff;
-  color: var(--ink);
-  padding: clamp(32px, 4vw, 48px);
-  border: 1px solid var(--border);
-  width: var(--page-width, 720px);
-  min-height: var(--page-height, auto);
-  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  aspect-ratio: var(--page-aspect, auto);
+  height: 100%;
+  gap: 20px;
 }
 
-.invoice__head {
-  display: flex;
-  justify-content: space-between;
-  gap: 18px;
-  border-bottom: 2px solid rgba(var(--accent-rgb), 0.6);
-  padding-bottom: 16px;
-}
-
-.invoice__identity {
-  display: flex;
+.invoice__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) auto;
   gap: 16px;
-  align-items: center;
+  align-items: start;
 }
 
 .invoice__logo {
-  max-width: 160px;
-  max-height: 60px;
+  justify-self: end;
+  align-self: start;
+  padding: 8px 12px;
+  border: 1px solid var(--outline);
+  min-width: 120px;
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
 }
 
-.invoice__tag {
+[data-theme="dark"] .invoice__logo {
+  background: rgba(15, 22, 35, 0.6);
+}
+
+.invoice__logo img {
+  max-height: 56px;
+  width: auto;
+}
+
+.invoice__logo--empty {
+  border: 1px dashed var(--outline);
+  color: var(--ink-muted);
+  font-size: 10px;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  letter-spacing: 0.48em;
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--accent);
-  padding: 6px 12px;
-  border: 1px solid rgba(var(--accent-rgb), 0.4);
-  background: rgba(var(--accent-rgb), 0.12);
 }
 
 .invoice__meta {
-  text-align: right;
-  font-size: 13px;
-  color: var(--ink-muted);
-}
-
-.invoice__meta strong {
-  display: block;
-  font-size: 15px;
-  color: var(--ink-strong);
-}
-
-.invoice__grid {
+  border: 1px solid var(--accent);
+  padding: 12px 16px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-}
-
-.invoice-panel {
-  padding: 14px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  background: transparent;
-  border: 1px solid transparent;
-}
-
-.invoice-panel__title {
-  text-transform: uppercase;
-  letter-spacing: 0.28em;
-  font-size: 11px;
-  color: var(--ink-muted);
-}
-
-.invoice-panel__body {
+  gap: 6px;
   font-size: 13px;
+}
+
+.invoice__title {
+  font-size: 20px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0;
+}
+
+.invoice__status {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.16em;
   color: var(--ink);
 }
 
-.invoice-table {
-  width: 100%;
-  border-collapse: collapse;
+[data-theme="dark"] .invoice__status {
+  color: #f0f4ff;
 }
 
-.invoice-table th,
-.invoice-table td {
-  border: 1px solid var(--border);
-  padding: 8px 10px;
+.invoice__summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  font-size: 13px;
+}
+
+.invoice__summary strong {
+  color: var(--accent);
+}
+
+.invoice__addresses {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+  font-size: 13px;
+}
+
+.invoice__addresses h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  color: var(--accent);
+  margin: 0 0 8px;
+}
+
+.invoice__dates {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  border: 1px solid var(--outline);
+  padding: 12px;
+}
+
+.invoice__dates span {
+  min-width: 140px;
+}
+
+.invoice__table {
+  border: 1px solid var(--accent);
+  border-collapse: collapse;
+  width: 100%;
   font-size: 12px;
 }
 
-.invoice-table th {
+.invoice__table thead {
+  background: var(--accent);
+  color: #fff;
   text-transform: uppercase;
-  letter-spacing: 0.24em;
-  color: var(--accent);
-  background: rgba(var(--accent-rgb), 0.1);
+  letter-spacing: 0.1em;
 }
 
-.invoice-table td:nth-child(2) {
-  text-align: center;
+.invoice__table th,
+.invoice__table td {
+  padding: 8px 10px;
+  border: 1px solid var(--outline);
+  vertical-align: top;
 }
 
-.invoice-table td:nth-child(3),
-.invoice-table td:nth-child(4) {
+.invoice__table tbody tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+[data-theme="dark"] .invoice__table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.invoice__totals {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 32px;
+  font-size: 14px;
+}
+
+.invoice__totals span {
+  display: inline-flex;
+  flex-direction: column;
   text-align: right;
 }
 
-.invoice-summary {
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
-  gap: 16px;
+.invoice__totals strong {
+  font-size: 18px;
+  color: var(--accent);
 }
 
-.invoice-summary__totals {
-  padding: 14px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 13px;
-  background: transparent;
-  border: 1px solid transparent;
+.invoice__notes {
+  border: 1px solid var(--outline);
+  padding: 12px 16px;
+  font-size: 12px;
 }
 
-.invoice-summary__line,
-.invoice-summary__total {
+.invoice__notes h4 {
+  margin: 0 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+
+.invoice__footer {
+  border-top: 1px solid var(--outline);
+  padding-top: 12px;
+  font-size: 11px;
   display: flex;
   justify-content: space-between;
-}
-
-.invoice-summary__total {
-  font-weight: 700;
-  font-size: 14px;
-  color: var(--ink-strong);
-  border-top: 1px solid rgba(var(--accent-rgb), 0.35);
-  padding-top: 8px;
-}
-
-.invoice-summary__note {
-  font-size: 12px;
   color: var(--ink-muted);
 }
 
-.invoice--outline .invoice-panel,
-.invoice--outline .invoice-summary__totals {
-  border: 1px solid var(--border);
-  background: #ffffff;
-  box-shadow: inset 0 -3px 0 rgba(var(--accent-rgb), 0.35);
+.invoice__footer span:last-child {
+  text-align: right;
 }
 
-.invoice--solid .invoice-panel,
-.invoice--solid .invoice-summary__totals {
-  border: none;
-  background: rgba(var(--accent-rgb), 0.16);
-}
+@media (max-width: 1100px) {
+  .workspace__body {
+    grid-template-columns: 1fr;
+  }
 
-.invoice--solid .invoice-table th {
-  background: rgba(var(--accent-rgb), 0.18);
-}
+  .preview {
+    position: static;
+  }
 
-@media (max-width: 960px) {
-  main.app {
-    padding-inline: clamp(14px, 6vw, 32px);
+  .sheet {
+    width: min(100%, 520px);
   }
 }
 
 @media (max-width: 720px) {
-  .preview__header,
-  .section-head,
-  .masthead {
+  .workspace__masthead {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .masthead__meta,
-  .preview__hint {
-    max-width: 32ch;
+  .workspace__toggles {
+    align-self: flex-end;
   }
 
-  .preview__actions {
-    width: 100%;
-    justify-content: flex-start;
-    flex-direction: column;
-  }
-
-  .preview__actions .btn {
-    width: 100%;
-  }
-
-  .invoice {
-    width: 100%;
-    padding: 24px;
-  }
-
-  .invoice__head {
-    flex-direction: column;
-    text-align: left;
-  }
-
-  .invoice__meta {
-    text-align: left;
-  }
-
-  .invoice-summary {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  html[data-theme='system'] .card:not(.preview),
-  html[data-theme='dark'] .card:not(.preview) {
-    background: color-mix(in srgb, currentColor 8%, transparent);
-  }
-
-  html[data-theme='system'] .preview.card,
-  html[data-theme='dark'] .preview.card {
-    background: #ffffff;
-    color: var(--ui-fg-light);
-  }
-
-  html[data-theme='system'] .preview__canvas,
-  html[data-theme='dark'] .preview__canvas {
-    background: #f4f4f4;
-    border-color: rgba(0, 0, 0, 0.12);
+  .preview__toolbar {
+    justify-content: space-between;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the invoice generator into a guided workspace with theme and accent controls, sender/client sections, payment guidance, and a live preview panel
- refresh the styling to mimic a KiCad schematic with grid overlays, dual themes, and responsive layout for the form, preview, and invoice surface
- replace the JavaScript with stateful sample data, automatic line-item math, filtered rows, color persistence, and PDF export tuned to the new layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc0aba83a883338face3695fac5278